### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM node:alpine AS docker_build
 
 WORKDIR /usr/builds/xiv-dicy
 
-ENV DATABASE_URL=file:storage/dicy.db
-
 COPY bot/dist ./dist/
 COPY config/prod.ts ./config/
 COPY bot/package-lock.json bot/package.json ./


### PR DESCRIPTION
removed the `ENV DATABASE_URL`, reason: "Invalid reason to keep this even if to pull from a public docker file"